### PR TITLE
Proposed one year cap to feed_end_date

### DIFF
--- a/en/feed_info.md
+++ b/en/feed_info.md
@@ -3,6 +3,6 @@
 
 | Field Name | Recommendation |
 | --- | --- |
-| feed_start_date & feed_end_date | Should be included |
+| feed_start_date & feed_end_date | Should be included. Feed_end_date should be set no more than one year into the future. |
 | feed_version | Should be included |
 | feed_contact_email & feed_contact_url | Provide at least one |


### PR DESCRIPTION
Best Practice Proposal:

Many transit providers change their schedules infrequently, and reasonably don't want to update their GTFS feeds more than they need to. But data consumers need to know that they're using the most recent version of the provider's data, and a feed set to expire in 75 years could easily be found later and incorrectly assumed to be correct. How far in advance is it reasonable to have a feed expire? After discussion with the GTFS community in the MobilityData slack, consensus emerged for setting feed_end_dates no more than one year into the future.

Use Cases:

Cal-ITP has found this to be an issue. One transit provider in California hired a vendor in 2011 to create their GTFS data, setting it to end in 2021. The contract with the vendor ended sometime in the middle of that decade, the schedule changed, and the provider didn't have the resources to hire a new vendor to update the data. This left the data "valid" but incorrect. A sooner end date would have prevented this issue, by at least indicating to data consumers that something was likely amiss.

**Best Practice Proposal:**

Summarize the Best Practice being proposed in the pull request including how it relates to any issues (include the #number, or link them).

**Use Cases:** 

Demonstrate the Best Practice proposal through real-life use cases. Use cases should cover a diversity of transit systems. At least 3 use cases should be provided.

**Data Examples:**

Demonstrate how the Best Practice would appear in GTFS Schedule.

**Public-facing Implementation (Optional):**

Show a public-facing implementation of the proposed Best Practice to demonstrate its value.
