### PR TITLE
Maintain persistent trip_id across data iterations as a best practice

### DIFF
--- a/en/best-practices.md
+++ b/en/best-practices.md
@@ -16,7 +16,7 @@ Practices are organized into four primary sections:
 
 * Datasets should be published at a public, permanent URL, including the zip file name. (e.g., www.agency.org/gtfs/gtfs.zip). Ideally, the URL should be directly downloadable without requiring login to access the file, to facilitate download by consuming software applications. While it is recommended (and the most common practice) to make a GTFS dataset openly downloadable, if a data provider does need to control access to GTFS for licensing or other reasons, it is recommended to control access to the GTFS dataset using API keys, which will facilitate automatic downloads.
 * GTFS data is published in iterations so that a single file at a stable location always contains the latest official description of service for a transit agency (or agencies).
-* Maintain persistent identifiers (id fields) for `stop_id`, `route_id`, and `agency_id` across data iterations whenever possible.
+* Maintain persistent identifiers (id fields) for `stop_id`, `route_id`, `trip_id` and `agency_id` across data iterations whenever possible.
 * One GTFS dataset should contain current and upcoming service (sometimes called a “merged” dataset). Google transitfeed tool's [merge function](https://github.com/google/transitfeed/wiki/Merge) can be used to create a merged dataset from two different GTFS feeds.
     * At any time, the published GTFS dataset should be valid for at least the next 7 days, and ideally for as long as the operator is confident that the schedule will continue to be operated.
     * If possible, the GTFS dataset should cover at least the next 30 days of service.


### PR DESCRIPTION
Changing trip_id across GTFS schedule data iterations can lead to temporary mismatched trip_id when processing corresponding GTFS-RT feed while the new schedule data is being updated. This is because the update is usually not instant, during the update window the GTFS-RT feed processor can only accept one schedule data version, which may or may not match the version used in GTFS-RT feed. It's better to keep the trip_id stable whenever possible.

**Best Practice Proposal:**

Summarize the Best Practice being proposed in the pull request including how it relates to any issues (include the #number, or link them).

**Use Cases:** 

Demonstrate the Best Practice proposal through real-life use cases. Use cases should cover a diversity of transit systems. At least 3 use cases should be provided.

**Data Examples:**

Demonstrate how the Best Practice would appear in GTFS Schedule.

**Public-facing Implementation (Optional):**

Show a public-facing implementation of the proposed Best Practice to demonstrate its value.
