### PR TITLE
Make it clear to contributors where to suggest new best practices

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Best Practices for Structuring [GTFS Schedule](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md) Data.
 
+⚠️ NOTE: The best practices are in the process of being merged into the spec [(More info here)](https://github.com/google/transit/issues/396). If you'd like to suggest a new best practice, please go to https://github.com/google/transit/ to open an issue or create a PR. ⚠️
+
 ## Current Version
 **The current release is v1.1**
 


### PR DESCRIPTION
**Best Practice Proposal:**

As outlined in https://github.com/google/transit/issues/396, MobilityData and the community is working on merging best practices into the spec. While we work through each adoption phase, it needs to be clear to contributors where to go to suggest new best practices. Consolidating spec conversation on https://github.com/google/transit will help retain momentum and reduce confusion.

**Solution** 

This PR adds a notice to contributors to go to https://github.com/google/transit/ to suggest new best practices. Please share feedback on the phasing plan at https://github.com/google/transit/issues/396.