### PR TITLE
Remove Best Practices content merged into spec (Phase 2)

### DIFF
--- a/en/best-practices.md
+++ b/en/best-practices.md
@@ -6,38 +6,14 @@ For further background, see the [Frequently Asked Questions](#frequently-asked-q
 
 ## Document Structure
 
-Practices are organized into four primary sections:
+Practices are organized into two primary sections:
 
-* __[Dataset Publishing & General Practices](#dataset-publishing--general-practices):__ These practices relate to the overall structure of the GTFS dataset and to the manner in which GTFS datasets are published.
 * __[Practice Recommendations Organized by File](#practice-recommendations-organized-by-file):__ Recommendations are organized by file and field in the GTFS to facilitate mapping practices back to the official GTFS reference.
 * __[Practice Recommendations Organized by Case](#practice-recommendations-organized-by-case):__ With particular cases, such as loop routes, practices may need to be applied across several files and fields. Such recommendations are consolidated in this section.
-
-## Dataset Publishing & General Practices
-
-* Datasets should be published at a public, permanent URL, including the zip file name. (e.g., www.agency.org/gtfs/gtfs.zip). Ideally, the URL should be directly downloadable without requiring login to access the file, to facilitate download by consuming software applications. While it is recommended (and the most common practice) to make a GTFS dataset openly downloadable, if a data provider does need to control access to GTFS for licensing or other reasons, it is recommended to control access to the GTFS dataset using API keys, which will facilitate automatic downloads.
-* GTFS data is published in iterations so that a single file at a stable location always contains the latest official description of service for a transit agency (or agencies).
-* Maintain persistent identifiers (id fields) for `stop_id`, `route_id`, and `agency_id` across data iterations whenever possible.
-* One GTFS dataset should contain current and upcoming service (sometimes called a “merged” dataset). Google transitfeed tool's [merge function](https://github.com/google/transitfeed/wiki/Merge) can be used to create a merged dataset from two different GTFS feeds.
-    * At any time, the published GTFS dataset should be valid for at least the next 7 days, and ideally for as long as the operator is confident that the schedule will continue to be operated.
-    * If possible, the GTFS dataset should cover at least the next 30 days of service.
-* Remove old services (expired calendars) from the feed.
-* If a service modification will go into effect in 7 days or fewer, express this service change through a [GTFS-realtime](https://developers.google.com/transit/gtfs-realtime/) feed (service advisories or trip updates) rather than static GTFS dataset.
-* The web-server hosting GTFS data should be configured to correctly report the file modification date (see [HTTP/1.1 - Request for Comments 2616](https://tools.ietf.org/html/rfc2616#section-14.29), under Section 14.29).
 
 ## Practice Recommendations Organized by File
 
 This section shows practices organized by file and field, aligning with the [GTFS reference](https://github.com/google/transit/blob/master/gtfs/spec/en/reference.md).
-
-### All Files
-
-| Field Name | Recommendation |
-| --- | --- |
-| Mixed Case | All customer-facing text strings (including stop names, route names, and headsigns) should use Mixed Case (not ALL CAPS), following local conventions for capitalization of place names on displays capable of displaying lower case characters. |
-| | Examples: |
-| | Brighton Churchill Square |
-| | Villiers-sur-Marne |
-| | Market Street |
-| Abbreviations | Avoid use of abbreviations throughout the feed for names and other text (e.g. St. for Street) unless a location is called by its abbreviated name (e.g. “JFK Airport”). Abbreviations may be problematic for accessibility by screen reader software and voice user interfaces. Consuming software can be engineered to reliably convert full words to abbreviations for display, but converting from abbreviations to full words is prone to more risk of error. |
 
 ### agency.txt
 


### PR DESCRIPTION
Referenced from [Issue #396](https://github.com/google/transit/issues/396) in the google/transit repo.

A [recently implemented proposal](https://github.com/google/transit/pull/406) has merged specific best practices directly into the GTFS specification. This merge included content from the [Dataset Publishing & General Practice guidelines](https://gtfs.org/schedule/best-practices/#dataset-publishing-general-practices) and the [Practice Recommendations for all files](https://gtfs.org/schedule/best-practices/#all-files) sections from the Best Practices document.

This proposal removes the duplicated content from the Best Practices document, to avoid duplicity and consolidating a single source of truth.